### PR TITLE
Added a wrapper script for stopping AWS servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This script lets you start and (gracefully) stop a Cloudera Hadoop cluster. The 
 
 ##List of Scripts
  - startstopcluster.sh
+ - startstopec2instances.sh
  - python/stopcmservices.py
  - python/startcmservices.py
  - python/stopcdhservices.py
@@ -30,5 +31,13 @@ This script lets you start and (gracefully) stop a Cloudera Hadoop cluster. The 
 ```sh
 ./startstopcluster.sh start
 ./startstopcluster.sh stop
+```
+## Stopping AWS instances
+To reduce cost, AWS instances can be stopped after shutting down the cluster. This can also be used for starting instances.
+- Open 'startstopec2instances.sh' and edit parameters as per your environment
+- Execute the script
+``` sh
+./startstopec2instances.sh stop
+./startstopec2instances.sh start
 ```
 

--- a/startstopec2instances.sh
+++ b/startstopec2instances.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# This is a wrapper script for stopping and starting AWS instances from EC2.
+# This script is invoking a AWS Lambda fuction. Inorder to work, you have to
+# create the Lambda function in AWS console and the EC2 from which this script
+# is running should have 'aws cli' installed. This wrapper is written conidering
+# there is a fixed list of instances to start or stop. 
+#
+# Refer : https://github.com/bijohnvincent/ScheduleStartStopEc2Lambda
+# For details about setting up the Lambda function to stop and start instances.
+
+
+
+
+#################   Variables to be modified by user  ######################
+LambdaFunction="StartStopInstances"
+Region="eu-west-1"
+LambdaOurputFile='LambdaOuput.txt'
+LambdaLogFile="startstop.log"
+# Comma seperated InstanceList
+# eg: InstanceList="NameOfInstance1, NameOfInstance2" 
+InstanceList="NameNode1"
+############################################################################
+
+
+## Function definition Usagehelp()
+function usagehelp ()
+{
+	echo "Script usage help:"
+	echo "$0 start"
+	echo "$0 stop"
+}
+
+
+
+## Function definition start-stop()
+function start-stop ()
+{
+	echo date >> $LambdaLogFile
+	aws lambda invoke --log-type Tail --function-name "$LambdaFunction" --region "$Region" --payload '{"action": "'"$1"'","instances":"'"$InstanceList"'"}' "$LambdaOurputFile" >> $LambdaLogFile
+	echo "Status:"
+	tail -4 $LambdaLogFile |grep LogResult|cut -d\" -f4|base64 --decode
+}
+
+
+
+## Main
+case $1 in
+start )
+	echo "Starting ec2 instances" >> $LambdaLogFile
+	start-stop
+	;;
+stop )
+	echo "Stopping ec2 instances" >> $LambdaLogFile
+	start-stop
+	;;
+* )
+	usagehelp
+	exit 1;
+	;;
+esac


### PR DESCRIPTION
Added a wrapper script 'startstopec2instances.sh' for stopping the AWS instances after shutting down the cluster which helps to reduce AWS server running cost. This script will invoke a AWS Lambda function. https://github.com/bijohnvincent/ScheduleStartStopEc2Lambda 
